### PR TITLE
FEATURE: Adds a Cassandra config class

### DIFF
--- a/core/src/main/scala/com/socrata/thirdparty/typesafeconfig/CassandraConfig.scala
+++ b/core/src/main/scala/com/socrata/thirdparty/typesafeconfig/CassandraConfig.scala
@@ -1,0 +1,17 @@
+package com.socrata.thirdparty.typesafeconfig
+
+import com.typesafe.config.Config
+
+class CassandraConfig(config: Config, root: String) extends ConfigClass(config, root) {
+  val cluster = getString("cluster")
+  val keyspace = getString("keyspace")
+  val connectionPool = getConfig("connection-pool", new CassandraConnectionPoolConfig(_, _))
+}
+
+class CassandraConnectionPoolConfig(config: Config, root: String) extends ConfigClass(config, root) {
+  val name = getString("name")
+  val port = getInt("port")
+  val maxConnectionsPerHost = getInt("max-connections-per-host")
+  val seeds = getStringList("seeds").mkString(",")
+  val connectTimeout = getDuration("connect-timeout")
+}


### PR DESCRIPTION
So, I'm factoring out geocoding via Mapquest into a library for di2 and soda-fountain to share. It wants a Cassandra config, but di2 already uses a Cassandra config in places I don't want to add a geocoding related library as a dependency to. So this is the best place I can think to put it. 