### PR TITLE
EN-7163 - Add support for C* datacenters (for DI2)

### DIFF
--- a/core/src/main/scala/com/socrata/thirdparty/typesafeconfig/CassandraConfig.scala
+++ b/core/src/main/scala/com/socrata/thirdparty/typesafeconfig/CassandraConfig.scala
@@ -14,4 +14,5 @@ class CassandraConnectionPoolConfig(config: Config, root: String) extends Config
   val maxConnectionsPerHost = getInt("max-connections-per-host")
   val seeds = getStringList("seeds").mkString(",")
   val connectTimeout = getDuration("connect-timeout")
+  val datacenter = optionally[String]("datacenter")
 }


### PR DESCRIPTION
In preparation for datacenter replication, we want to make sure that
queries don't span across datacenters, potentially introducing large
latency.

Goes hand-in-hand with https://github.com/socrata/delta-importer-2/pull/140